### PR TITLE
systemd geth service file

### DIFF
--- a/geth-systemd-service.md
+++ b/geth-systemd-service.md
@@ -4,9 +4,9 @@
 [Unit]
 Description=Ethereum go client
 
+
 [Service]
-Type=simple
-ExecStart=geth 2>%h/.ethereum/geth.log
+ExecStart=/usr/bin/geth $ARGS
 
 [Install]
 WantedBy=default.target

--- a/geth-systemd-service.md
+++ b/geth-systemd-service.md
@@ -6,6 +6,7 @@ Description=Ethereum go client
 
 
 [Service]
+EnvironmentFile=%h/.ethereum/geth.conf
 ExecStart=/usr/bin/geth $ARGS
 
 [Install]


### PR DESCRIPTION
Some improvements:
1- no need to specify Type=simple. It is the default
2- no need to write a log file. Just use journalctl facilities
3- put all your options in one file in your home folder. It will then be easy to modify options: edit the geth.conf, reload the daemon, restart the service.
The config file shall contain one line:
## `$ARGS="--myOption --mySecondOption"`

I wrote a pull request to [go-ethereum (#2513)](https://github.com/ethereum/go-ethereum/pull/2513) as systemd is now default in many Linux distro. 

------------------ OPTIONAL
move the `geth.ipc` unix socket from the home directory and put it in the recommended and usual `/run/user/userID/` directory.
To achieve this, write a systemd socket unit file and add a require in service file.

``` Requires=geth.socket```

```
## /etc/systemd/user/geth.socket

[Unit]
Description=geth daemon (socket activation)

[Socket]
ListenStream=%t/geth.ipc

```
```
